### PR TITLE
Added Timer:Cancel() and Timer:Destroy()

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -136,6 +136,17 @@ function TimerClass:Stop()
 	RemoveFromArray(self)
 	EndTimer(self, self.State, time() - self.Started)
 end
+function TimerClass:Cancel()
+	RemoveFromArray(self)
+	EndTimer(self, self.State, time() - self.Started)
+	for _, Thread in next, self.YieldedThreads do
+		coroutine.resume(Thread, TimerEnum.Finished, time() - self.Started)
+	end
+end
+function TimerClass:Destroy()
+	table.clear(self)
+	self = nil
+end
 function TimerClass:IncrementTime(Delta)
 	self.Length += Delta
 end
@@ -144,7 +155,6 @@ end
 TimerClass.Yield = TimerClass.Wait
 TimerClass.Yield = TimerClass.Wait
 TimerClass.Play = TimerClass.Start
-TimerClass.Cancel = TimerClass.Stop
 TimerClass.Kill = TimerClass.Stop
 
 


### PR DESCRIPTION
Previously if you called Timer:Wait() there was no way to resume the thread other than waiting for the timer to finish. Now you can call Timer:Cancel() to resume the thread. Also added Timer:Destroy() method which will clear itself (this does not resume threads, though!)